### PR TITLE
Migration to hugo 0.22

### DIFF
--- a/layouts/_default/footer.html
+++ b/layouts/_default/footer.html
@@ -8,5 +8,5 @@
 		</ul>
 	</div>
 
-	<p>{{ with .Site.Params.Copyright }}{{ . | safeHTML }}{{ else }}&copy; {{.Now.Format "2006"}}. All rights reserved.{{end}}</p>
+	<p>{{ with .Site.Params.Copyright }}{{ . | safeHTML }}{{ else }}&copy; {{now.Format "2006"}}. All rights reserved.{{end}}</p>
 </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,7 +11,7 @@
 		{{ with .Site.Params.Copyright }}
 			{{ . | safeHTML }}
 		{{ else }}
-			&copy; 2014-{{.Now.Format "2006"}} {{ $author }}.
+			&copy; 2014-{{now.Format "2006"}} {{ $author }}.
 			<a href="http://creativecommons.org/licenses/by/3.0/">Some rights reserved</a>;
 			please attribute properly and link back. Powered by <a href="http://gohugo.io/">Hugo</a>.
 			Theme based on <a href="https://github.com/tmaiaroto/hugo-redlounge">hugo-redlougne</a>.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,7 +31,10 @@
   <link rel="shortcut icon" href="/favicon.png">
 
   <!-- RSS -->
-  <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ if .RSSLink }}
+	<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+	<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ end }}
 
   {{ partial "syntaxhighlight.html" . }}
 


### PR DESCRIPTION
Why:
- `RSSlink` is deprecated, use `RSSLink` instead
- `Page's Now` is to be deprecated, use `now.Format` instead

This change addresses the need by:
Changing the deprecated functions