### PR TITLE
Update RSS definition

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,10 +31,9 @@
   <link rel="shortcut icon" href="/favicon.png">
 
   <!-- RSS -->
-  {{ if .RSSLink }}
-	<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-	<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-  {{ end }}
+  {{ range .AlternativeOutputFormats -}}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
 
   {{ partial "syntaxhighlight.html" . }}
 


### PR DESCRIPTION
Because:
Updating the deprecated RSS definition, changed it with
https://gohugo.io/templates/rss/#configure-rss

This commit:
Updating the `header.html`